### PR TITLE
Updated requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,3 +15,4 @@ pytz>=2016.10
 six>=1.10.0
 sqlparse>=0.2.3
 requests>=2.13.0
+PyPrintful>=1.0.0a4


### PR DESCRIPTION
Development of the api wrapper has been moved to the github.com/559labs/pyPrintful project. Issues are still tracked here.